### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/diceapp-tests.yml
+++ b/.github/workflows/diceapp-tests.yml
@@ -1,5 +1,8 @@
 name: DiceApp CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ 'main']


### PR DESCRIPTION
Potential fix for [https://github.com/colinkershaw/die-by-the-browser/security/code-scanning/1](https://github.com/colinkershaw/die-by-the-browser/security/code-scanning/1)

In general, the fix is to explicitly restrict `GITHUB_TOKEN` permissions in the workflow to the least privilege necessary. For a simple test job that only checks out code and runs `npm` and `npx playwright` locally, `contents: read` is sufficient. You can set permissions either at the workflow (top) level or at the job level. Since there is only one job here, either is fine; the simplest is to add a `permissions` block at the root of the workflow.

Concretely, in `.github/workflows/diceapp-tests.yml`, add a `permissions:` section near the top (after `name:` and before `on:`) with `contents: read`. This ensures the `GITHUB_TOKEN` cannot modify repository contents or perform other write operations, while preserving all existing functionality because none of the steps require write access. No additional imports, methods, or other definitions are required, as this is purely YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
